### PR TITLE
feat(products): coming-soon teaser, homepage banners, top announcemen…

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import { Toaster } from '@/components/ui/toaster';
 import WhatsAppButton from '@/components/ui/WhatsAppButton';
 import { getBaseUrl } from '@/lib/site-config';
 import { ThemeProvider, ThemeScript } from '@/components/providers/ThemeProvider';
+import AnnouncementBar from '@/components/layout/AnnouncementBar';
 
 const inter = Inter({
   subsets: ['latin'],
@@ -408,6 +409,7 @@ export default function RootLayout({
 
       <body className={`${inter.variable} font-sans antialiased`}>
         <ThemeProvider defaultTheme="system" storageKey="webondev-theme">
+          <AnnouncementBar />
           {children}
           <WhatsAppButton />
           <Toaster />

--- a/app/products/[slug]/page.tsx
+++ b/app/products/[slug]/page.tsx
@@ -109,9 +109,16 @@ export default async function ProductPage({ params }: ProductPageProps) {
                 <li aria-current="page" className="text-slate-300">{product.name}</li>
               </ol>
             </nav>
-            <p className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-white/[0.04] border border-white/[0.08] text-xs text-brand-400 font-semibold mb-5">
-              <span className="w-1.5 h-1.5 rounded-full bg-brand-400" /> A Web On Dev Product · {product.category}
-            </p>
+            <div className="mb-5 flex flex-wrap items-center gap-2.5">
+              {product.comingSoon && (
+                <span className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wider ${product.theme.pill}`}>
+                  <span className={`h-1.5 w-1.5 rounded-full ${product.theme.dot}`} /> Coming soon
+                </span>
+              )}
+              <span className="inline-flex items-center gap-2 rounded-full border border-white/[0.08] bg-white/[0.04] px-3 py-1 text-xs font-semibold text-brand-400">
+                <span className="h-1.5 w-1.5 rounded-full bg-brand-400" /> A Web On Dev Product · {product.category}
+              </span>
+            </div>
             <h1 className="text-3xl sm:text-4xl lg:text-6xl font-bold text-white leading-[1.05] tracking-tight mb-4">
               {product.name}
             </h1>
@@ -124,7 +131,7 @@ export default async function ProductPage({ params }: ProductPageProps) {
                 rel="noopener"
                 className="inline-flex items-center justify-center gap-2 rounded-full bg-brand-500 px-7 py-3 font-semibold text-white hover:bg-brand-400 transition-colors"
               >
-                Visit {product.name} <ExternalLink className="w-4 h-4" />
+                Preview {product.name} <ExternalLink className="w-4 h-4" />
               </a>
               <Link
                 href="/contact"

--- a/app/products/page.tsx
+++ b/app/products/page.tsx
@@ -71,7 +71,14 @@ export default function ProductsPage() {
                 />
               </div>
               <div className="p-7">
-              <p className="text-[11px] uppercase tracking-wider text-brand-400 font-semibold mb-2">{p.category}</p>
+              <div className="mb-2 flex flex-wrap items-center gap-2">
+                {p.comingSoon && (
+                  <span className={`inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider ${p.theme.pill}`}>
+                    <span className={`h-1.5 w-1.5 rounded-full ${p.theme.dot}`} /> Coming soon
+                  </span>
+                )}
+                <p className={`text-[11px] uppercase tracking-wider font-semibold ${p.theme.eyebrow}`}>{p.category}</p>
+              </div>
               <h2 className="text-xl font-bold text-white mb-1 group-hover:text-brand-400 transition-colors">{p.name}</h2>
               <p className="text-sm text-slate-300 mb-3">{p.tagline}</p>
               <p className="text-sm text-slate-400 line-clamp-3 mb-4">{p.heroDescription}</p>

--- a/components/layout/AnnouncementBar.tsx
+++ b/components/layout/AnnouncementBar.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { X } from 'lucide-react';
+import { products } from '@/lib/products-data';
+
+const DISMISS_KEY = 'wod-products-announcement-dismissed';
+
+const AnnouncementBar = () => {
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    try {
+      if (localStorage.getItem(DISMISS_KEY) === '1') setVisible(false);
+    } catch {}
+  }, []);
+
+  if (!visible) return null;
+
+  const dismiss = () => {
+    setVisible(false);
+    try {
+      localStorage.setItem(DISMISS_KEY, '1');
+    } catch {}
+  };
+
+  return (
+    <div className="relative z-[60] w-full border-b border-white/[0.08] bg-gradient-to-r from-slate-950 via-[#0a1020] to-slate-950">
+      {/* hairline accent glow */}
+      <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-brand-500/40 to-transparent" />
+      <div className="relative mx-auto flex max-w-7xl flex-wrap items-center justify-center gap-x-3 gap-y-1 px-10 py-2 text-center text-[12px] sm:text-[13px]">
+        <span className="inline-flex items-center gap-1.5 font-semibold uppercase tracking-[0.14em] text-brand-400">
+          <span className="relative flex h-1.5 w-1.5">
+            <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-brand-400/70" />
+            <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-brand-400" />
+          </span>
+          Coming soon
+        </span>
+        <span aria-hidden className="hidden text-slate-600 sm:inline">·</span>
+        <span className="text-slate-300">Two products, built by Web On Dev —</span>
+        {products.map((p, i) => (
+          <React.Fragment key={p.slug}>
+            {i > 0 && <span aria-hidden className="text-slate-600">·</span>}
+            <Link
+              href={`/products/${p.slug}/`}
+              className={`font-semibold underline-offset-4 hover:underline ${p.theme.barText}`}
+            >
+              {p.name}
+            </Link>
+          </React.Fragment>
+        ))}
+      </div>
+      <button
+        type="button"
+        onClick={dismiss}
+        aria-label="Dismiss announcement"
+        className="absolute right-2 top-1/2 -translate-y-1/2 rounded-md p-1.5 text-slate-500 transition-colors hover:bg-white/[0.06] hover:text-slate-300"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  );
+};
+
+export default AnnouncementBar;

--- a/components/sections/ProductsShowcase.tsx
+++ b/components/sections/ProductsShowcase.tsx
@@ -4,82 +4,122 @@ import Link from 'next/link';
 import { ArrowRight, ExternalLink } from 'lucide-react';
 import { products } from '@/lib/products-data';
 
-// Homepage "Our Products" strip — showcases real products Web On Dev built
-// (strong proof-of-work / E-E-A-T signal). Static (no JS-gated visibility).
+// Homepage "Our Products" banners — large, alternating, browser-framed screenshots
+// with each product's own accent glow. Real products Web On Dev built (proof-of-work),
+// teased as "coming soon".
 const ProductsShowcase = () => {
   return (
-    <section className="relative py-16 sm:py-20 lg:py-28 bg-[#030712] overflow-hidden">
-      <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/[0.06] to-transparent" />
-      <div className="relative z-10 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="text-center mb-10 sm:mb-14">
-          <div className="inline-flex items-center gap-2 px-3 py-1 sm:px-4 sm:py-1.5 rounded-full gradient-border-subtle text-brand-400 text-xs sm:text-sm font-medium mb-3 sm:mb-4">
-            <span className="w-1.5 h-1.5 rounded-full bg-brand-400" />
+    <section className="relative overflow-hidden bg-[#030712] py-20 sm:py-24 lg:py-28">
+      <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/[0.06] to-transparent" />
+
+      <div className="relative z-10 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        {/* Section header */}
+        <div className="mb-12 max-w-2xl sm:mb-16">
+          <div className="mb-4 inline-flex items-center gap-2 rounded-full gradient-border-subtle px-3 py-1 text-xs font-medium text-brand-400 sm:px-4 sm:py-1.5 sm:text-sm">
+            <span className="h-1.5 w-1.5 rounded-full bg-brand-400" />
             Our Products
           </div>
-          <h2 className="text-2xl sm:text-3xl lg:text-5xl font-bold text-white mb-3 sm:mb-4 leading-[1.1]">
-            We build &amp; run our own <span className="gradient-text">products</span>
+          <h2 className="text-2xl font-bold leading-[1.1] text-white sm:text-3xl lg:text-5xl">
+            Two products we built —{' '}
+            <span className="gradient-text">launching soon</span>
           </h2>
-          <p className="text-sm sm:text-base text-slate-400 max-w-2xl mx-auto">
-            We don&apos;t just ship software for clients — we design, launch, and operate our own. Proof that we build real, production products end-to-end.
+          <p className="mt-4 max-w-xl text-sm text-slate-400 sm:text-base">
+            We don&apos;t just ship software for clients. We design, build, and run our own — proof that we take a product from idea to launch end-to-end.
           </p>
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-5 sm:gap-6">
-          {products.map((p) => (
-            <div
-              key={p.slug}
-              className="group rounded-2xl border border-white/[0.08] bg-white/[0.02] overflow-hidden hover:border-brand-500/20 transition-colors"
-            >
-              <Link href={`/products/${p.slug}/`} className="block border-b border-white/[0.06] bg-black/20" aria-label={p.name}>
-                <Image
-                  src={p.screenshot}
-                  alt={`${p.name} screenshot`}
-                  width={1280}
-                  height={800}
-                  className="w-full h-auto"
-                  unoptimized
-                />
-              </Link>
-              <div className="p-6 sm:p-8">
-              <div className="flex items-center justify-between mb-3">
-                <p className="text-[11px] uppercase tracking-wider text-brand-400 font-semibold">{p.category}</p>
-                <a
-                  href={p.liveUrl}
-                  target="_blank"
-                  rel="noopener"
-                  className="inline-flex items-center gap-1 text-xs text-slate-500 hover:text-brand-400 transition-colors"
-                  aria-label={`Visit ${p.name}`}
-                >
-                  {p.liveLabel} <ExternalLink className="w-3 h-3" />
-                </a>
-              </div>
-              <h3 className="text-xl sm:text-2xl font-bold text-white mb-2 group-hover:text-brand-400 transition-colors">
-                {p.name}
-              </h3>
-              <p className="text-sm text-slate-300 mb-2">{p.tagline}</p>
-              <p className="text-sm text-slate-400 mb-5 line-clamp-3">{p.heroDescription}</p>
-              <div className="flex flex-wrap gap-2 mb-6">
-                {p.highlights.slice(0, 3).map((h) => (
-                  <span key={h.label} className="text-xs rounded-full bg-white/[0.04] border border-white/[0.08] px-3 py-1.5 text-slate-300">
-                    <span className="text-brand-400 font-semibold">{h.value}</span> {h.label}
-                  </span>
-                ))}
-              </div>
-              <Link
-                href={`/products/${p.slug}/`}
-                className="inline-flex items-center gap-1.5 text-brand-400 hover:text-brand-300 font-semibold text-sm"
+        {/* Banners */}
+        <div className="space-y-6 sm:space-y-8">
+          {products.map((p, i) => {
+            const imageRight = i % 2 === 1;
+            return (
+              <article
+                key={p.slug}
+                className="group relative overflow-hidden rounded-3xl border border-white/[0.08] bg-white/[0.015] transition-colors hover:border-white/[0.14]"
               >
-                Explore {p.name} <ArrowRight className="w-4 h-4 group-hover:translate-x-0.5 transition-transform" />
-              </Link>
-              </div>
-            </div>
-          ))}
-        </div>
+                {/* accent glow drawn from the product's own world */}
+                <div
+                  aria-hidden
+                  className="pointer-events-none absolute inset-0 opacity-70"
+                  style={{
+                    background: `radial-gradient(70% 90% at ${imageRight ? '85%' : '15%'} 50%, ${p.theme.glow}, transparent 70%)`,
+                  }}
+                />
 
-        <div className="text-center mt-10">
-          <Link href="/products" className="inline-flex items-center gap-2 text-sm text-slate-400 hover:text-brand-400 font-semibold transition-colors">
-            View all products <ArrowRight className="w-4 h-4" />
-          </Link>
+                <div className="relative grid items-stretch gap-0 lg:grid-cols-2">
+                  {/* Screenshot in a clean browser frame */}
+                  <div className={`p-5 sm:p-8 lg:p-10 ${imageRight ? 'lg:order-2' : ''}`}>
+                    <div className="overflow-hidden rounded-xl border border-white/[0.08] bg-black/30 shadow-[0_24px_70px_-24px_rgba(0,0,0,0.7)]">
+                      <div className="flex items-center gap-1.5 border-b border-white/[0.06] bg-white/[0.02] px-3.5 py-2.5">
+                        <span className="h-2.5 w-2.5 rounded-full bg-white/15" />
+                        <span className="h-2.5 w-2.5 rounded-full bg-white/15" />
+                        <span className="h-2.5 w-2.5 rounded-full bg-white/15" />
+                        <span className="ml-3 truncate rounded-md bg-white/[0.04] px-2.5 py-1 text-[11px] text-slate-500">
+                          {p.liveLabel}
+                        </span>
+                      </div>
+                      <Image
+                        src={p.screenshot}
+                        alt={`${p.name} — product preview`}
+                        width={1280}
+                        height={800}
+                        className="h-auto w-full"
+                        unoptimized
+                      />
+                    </div>
+                  </div>
+
+                  {/* Content */}
+                  <div className={`flex flex-col justify-center p-6 sm:p-8 lg:p-12 ${imageRight ? 'lg:order-1' : ''}`}>
+                    <div className="mb-4 flex flex-wrap items-center gap-2.5">
+                      {p.comingSoon && (
+                        <span className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wider ${p.theme.pill}`}>
+                          <span className={`h-1.5 w-1.5 rounded-full ${p.theme.dot}`} />
+                          Coming soon
+                        </span>
+                      )}
+                      <span className={`text-[11px] font-semibold uppercase tracking-wider ${p.theme.eyebrow}`}>
+                        {p.category}
+                      </span>
+                    </div>
+
+                    <h3 className="text-2xl font-bold text-white sm:text-3xl">{p.name}</h3>
+                    <p className="mt-2 text-base text-slate-300">{p.tagline}</p>
+                    <p className="mt-3 text-sm leading-relaxed text-slate-400 line-clamp-3">{p.heroDescription}</p>
+
+                    <div className="mt-6 flex flex-wrap gap-2">
+                      {p.highlights.slice(0, 3).map((h) => (
+                        <span
+                          key={h.label}
+                          className="rounded-full border border-white/[0.08] bg-white/[0.03] px-3 py-1.5 text-xs text-slate-300"
+                        >
+                          <span className="font-semibold text-white">{h.value}</span> {h.label}
+                        </span>
+                      ))}
+                    </div>
+
+                    <div className="mt-8 flex flex-wrap items-center gap-3">
+                      <Link
+                        href={`/products/${p.slug}/`}
+                        className="inline-flex items-center gap-2 rounded-full bg-brand-500 px-6 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-brand-400"
+                      >
+                        Explore {p.name}
+                        <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+                      </Link>
+                      <a
+                        href={p.liveUrl}
+                        target="_blank"
+                        rel="noopener"
+                        className="inline-flex items-center gap-1.5 rounded-full border border-white/10 px-5 py-2.5 text-sm font-semibold text-slate-300 transition-colors hover:border-white/20 hover:bg-white/[0.03]"
+                      >
+                        Preview <ExternalLink className="h-3.5 w-3.5" />
+                      </a>
+                    </div>
+                  </div>
+                </div>
+              </article>
+            );
+          })}
         </div>
       </div>
     </section>

--- a/lib/products-data.ts
+++ b/lib/products-data.ts
@@ -24,6 +24,17 @@ export interface Product {
   liveUrl: string;
   liveLabel: string; // e.g. "weddingwala.pk"
   screenshot: string; // real screenshot of the live product (1440x900)
+  comingSoon: boolean;
+  // Product-specific accent (drawn from each product's own world), used for the
+  // homepage banners, badges, and glows so each product keeps its own personality
+  // inside the shared dark brand canvas.
+  theme: {
+    eyebrow: string; // tailwind text color for the category eyebrow
+    dot: string; // tailwind bg for the status pulse dot
+    pill: string; // tailwind classes for the "Coming soon" pill
+    glow: string; // CSS color for the radial accent glow
+    barText: string; // tailwind text color for the top-bar link
+  };
   category: string; // short label e.g. "Wedding Marketplace"
   appCategory: string; // schema applicationCategory
   heroDescription: string;
@@ -47,6 +58,14 @@ export const products: Product[] = [
     liveUrl: 'https://schedura.ai',
     liveLabel: 'schedura.ai',
     screenshot: '/images/products/schedura.jpg',
+    comingSoon: true,
+    theme: {
+      eyebrow: 'text-indigo-300',
+      dot: 'bg-indigo-400',
+      pill: 'bg-indigo-500/15 text-indigo-200 border-indigo-400/30',
+      glow: 'rgba(99,102,241,0.20)',
+      barText: 'text-indigo-200 hover:text-indigo-100',
+    },
     category: 'AI Social Media SaaS',
     appCategory: 'BusinessApplication',
     heroDescription:
@@ -114,6 +133,14 @@ export const products: Product[] = [
     liveUrl: 'https://weddingwala.pk',
     liveLabel: 'weddingwala.pk',
     screenshot: '/images/products/wedding-wala.jpg',
+    comingSoon: true,
+    theme: {
+      eyebrow: 'text-rose-300',
+      dot: 'bg-rose-400',
+      pill: 'bg-rose-500/15 text-rose-200 border-rose-400/30',
+      glow: 'rgba(244,63,94,0.18)',
+      barText: 'text-rose-200 hover:text-rose-100',
+    },
     category: 'Wedding Vendor Marketplace',
     appCategory: 'BusinessApplication',
     heroDescription:


### PR DESCRIPTION
…t bar

- Top announcement bar (site-wide, dismissible via localStorage) teasing both products: "Coming soon — Schedura · Wedding Wala". Added in app/layout.tsx above the header; on-brand, hairline accent.
- Homepage product section redesigned into two large alternating banners with a browser-framed real screenshot, each product's own accent glow (Schedura indigo, Wedding Wala rose), a "Coming soon" pill, highlight chips, and Explore + Preview CTAs.
- "Coming soon" pills added to product hub cards and product page hero; hero CTA -> "Preview". Per-product accent theming in lib/products-data.ts.

Verified in headless browser: top bar + both banners render cleanly and on their accent. Build exit 0.